### PR TITLE
Adds missing specs for documented behavior and changes the implementation to actually behave this way

### DIFF
--- a/lib/smart_properties.rb
+++ b/lib/smart_properties.rb
@@ -110,12 +110,18 @@ module SmartProperties
 
     ##
     # Returns the list of smart properties that for this class. This 
-    # includes the properties than have been defined in the parent classes.
+    # includes the properties that have been defined in the parent classes.
     #
     # @return [Array<Property>] The list of properties.
     #
     def properties
-      (@_smart_properties || {}).dup
+      @_smart_properties ||= begin        
+        parent = if self != SmartProperties
+          (ancestors[1..-1].find { |klass| klass.ancestors.include?(SmartProperties) && klass != SmartProperties })
+        end
+        
+        parent ? parent.properties.dup : {}
+      end
     end
 
     ##
@@ -166,18 +172,10 @@ module SmartProperties
     #                           :required => true
     #
     def property(name, options = {})
-      @_smart_properties ||= begin        
-        parent = if self != SmartProperties
-          (ancestors[1..-1].find { |klass| klass.ancestors.include?(SmartProperties) && klass != SmartProperties })
-        end
-        
-        parent ? parent.properties : {}
-      end
-      
       p = Property.new(name, options)
       p.define(self)
-      
-      @_smart_properties[name] = p
+
+      properties[name] = p
     end
     protected :property
 

--- a/spec/smart_properties_spec.rb
+++ b/spec/smart_properties_spec.rb
@@ -38,6 +38,9 @@ describe SmartProperties do
       klass
     end
 
+    its(:properties) { should have(1).property }
+    its(:properties) { should have_key(:title) }
+
     context "instances of this class" do
       
       klass = subject.call
@@ -74,7 +77,47 @@ describe SmartProperties do
       end
 
     end
-    
+
+    context "when subclassed" do
+
+      superklass = subject.call
+
+      subject do
+        Class.new(superklass)
+      end
+
+      its(:properties) { should have(1).property }
+      its(:properties) { should have_key(:title) }
+
+      context "instances of this subclass" do
+
+        klass = subject.call
+
+        subject do
+          klass.new
+        end
+
+        it { should respond_to(:title) }
+        it { should respond_to(:title=) }
+
+      end
+
+      context "instances of this subclass that have been intialized from a set of attributes" do
+        
+        klass = subject.call
+        
+        subject do
+          klass.new :title => stub(:to_title => 'Message')
+        end
+        
+        it "should have the correct title" do
+          subject.title.should be == 'Message'
+        end
+        
+      end
+      
+    end
+
     context "when subclassed and extended with a property called text" do
       
       superklass = subject.call
@@ -86,7 +129,11 @@ describe SmartProperties do
           end
         end
       end
-      
+
+      its(:properties) { should have(2).property }
+      its(:properties) { should have_key(:title) }
+      its(:properties) { should have_key(:text) }
+
       context "instances of this subclass" do
         
         klass = subject.call
@@ -144,7 +191,11 @@ describe SmartProperties do
           end
         end
       end
-      
+
+      its(:properties) { should have(2).property }
+      its(:properties) { should have_key(:title) }
+      its(:properties) { should have_key(:type) }
+
       context "instances of this class" do
         
         klass = subject.call


### PR DESCRIPTION
This changes the implementation of `.properties` and `.property` to behave like described in the documentation. With this fix it is possible to read a subclass' properties without having to define properties of its own. This also fixes initalization of those subclasses without own properties.
