### PR TITLE
Use custom ArgumentError exception with metadata

### DIFF
--- a/spec/smart_properties_spec.rb
+++ b/spec/smart_properties_spec.rb
@@ -2,6 +2,12 @@ require 'spec_helper'
 
 describe SmartProperties do
 
+  describe SmartProperties::ArgumentError do
+    subject(:instance) { SmartProperties::ArgumentError.new }
+    it { should respond_to(:errors) }
+    it { should respond_to(:errors=) }
+  end
+
   context "when extending an other class" do
     subject(:klass) do
       Class.new.tap do |c|
@@ -21,7 +27,7 @@ describe SmartProperties do
               property :title, :invalid_option => 'boom'
             end
           end
-        }.to raise_error(ArgumentError, "SmartProperties do not support the following configuration options: invalid_option.")
+        }.to raise_error(SmartProperties::ArgumentError, "SmartProperties do not support the following configuration options: invalid_option.")
       end
 
       it "should raise an error reporting three invalid options when three invalid options were given" do
@@ -31,7 +37,7 @@ describe SmartProperties do
               property :title, :invalid_option_1 => 'boom', :invalid_option_2 => 'boom', :invalid_option_3 => 'boom'
             end
           end
-        }.to raise_error(ArgumentError, "SmartProperties do not support the following configuration options: invalid_option_1, invalid_option_2, invalid_option_3.")
+        }.to raise_error(SmartProperties::ArgumentError, "SmartProperties do not support the following configuration options: invalid_option_1, invalid_option_2, invalid_option_3.")
       end
     end
   end
@@ -77,7 +83,9 @@ describe SmartProperties do
       end
 
       it "should not allow to set nil as title" do
-        expect { instance.title = nil }.to raise_error(ArgumentError, "TestDummy requires the property title to be set")
+        expect { instance.title = nil }.to raise_error(SmartProperties::ArgumentError, "TestDummy requires the property title to be set") {|error|
+          error.errors[:title].should == 'must be set'
+        }
       end
 
       it "should not allow to set objects as title that do not respond to #to_title" do
@@ -280,7 +288,9 @@ describe SmartProperties do
       end
 
       it "should not allow to set :maybe as value for visible" do
-        expect { instance.visible = :maybe }.to raise_error(ArgumentError, "TestDummy does not accept :maybe as value for the property visible")
+        expect { instance.visible = :maybe }.to raise_error(SmartProperties::ArgumentError, "TestDummy does not accept :maybe as value for the property visible") {|error|
+          error.errors[:visible].should == 'does not accept :maybe as value'
+        }
       end
     end
   end
@@ -325,7 +335,9 @@ describe SmartProperties do
       subject(:instance) { klass.new }
 
       it 'should not a accept "invalid" as value for license_plate' do
-        expect { instance.license_plate = "invalid" }.to raise_error(ArgumentError, 'TestDummy does not accept "invalid" as value for the property license_plate')
+        expect { instance.license_plate = "invalid" }.to raise_error(SmartProperties::ArgumentError, 'TestDummy does not accept "invalid" as value for the property license_plate') {|error|
+          error.errors[:license_plate].should == 'does not accept "invalid" as value'
+        }
       end
 
       it 'should accept "NE RD 1337" as license plate' do
@@ -512,7 +524,9 @@ describe SmartProperties do
 
       context "when created with no arguments" do
         it "should raise an error stating that required properties are missing" do
-          expect { klass.new }.to raise_error(ArgumentError, "Dummy requires the following properties to be set: title")
+          expect { klass.new }.to raise_error(SmartProperties::ArgumentError, "Dummy requires the following properties to be set: title") {|error|
+            error.errors[:title].should == 'must be set'
+          }
         end
       end
     end
@@ -538,7 +552,9 @@ describe SmartProperties do
 
     context "when created with no name and anonymous being set to false" do
       it "should raise an error indicating that a required property was not specified" do
-        expect { klass.new anonymous: false }.to raise_error(ArgumentError, "Dummy requires the following properties to be set: name")
+        expect { klass.new anonymous: false }.to raise_error(SmartProperties::ArgumentError, "Dummy requires the following properties to be set: name") {|error|
+          error.errors[:name].should == "must be set"
+        }
       end
     end
 


### PR DESCRIPTION
I want to use smart properties to validate/sanitize hashes. However, if this is connected to a user facing interface, you usually want to provide some kind of feedback, when the property interfaces are not satisfied.

So I added a custom exception class, called `SmartProperties::ArgumentError`, that has an additional property called `errors`. It contains a hash of the structure `invalid_field => error explanation` that can be used e.g. for rendering a JSON error response.

Please note that  `SmartProperties::ArgumentError` inherits from  `ArgumentError` to keep backwards compatibility.

Cheers!
