### PR TITLE
Prevent unnecessary evaluation of default blocks

### DIFF
--- a/lib/smart_properties.rb
+++ b/lib/smart_properties.rb
@@ -318,7 +318,7 @@ module SmartProperties
 
     # Assign attributes or default values
     properties.each do |_, property|
-      value = attrs.fetch(property.name, property.default(self))
+      value = attrs.fetch(property.name) { property.default(self) }
       send(:"#{property.name}=", value) unless value.nil?
     end
 


### PR DESCRIPTION
Lambda statements provided to the default configuration option are no longer evaulated every time. Instead, they are only evaluated if no value for a particular property has been given.