### PR TITLE
Initialization of required overridden properties

### DIFF
--- a/lib/smart_properties.rb
+++ b/lib/smart_properties.rb
@@ -339,7 +339,7 @@ module SmartProperties
 
     # Check presence of all required properties
     faulty_properties =
-      properties.select { |_, property| property.required?(self) && send(property.name).nil? }.map(&:last)
+      properties.select { |_, property| property.required?(self) && instance_variable_get("@#{property.name}").nil? }.map(&:last)
     unless faulty_properties.empty?
       error = SmartProperties::InitializationError.new(self, faulty_properties)
       raise error

--- a/spec/smart_properties_spec.rb
+++ b/spec/smart_properties_spec.rb
@@ -431,6 +431,28 @@ describe SmartProperties do
     end
   end
 
+  context 'when used to build a class that has a required property with no default called :text whose getter is overriden' do
+    subject(:klass) do
+      Class.new.tap do |c|
+        c.send(:include, described_class)
+
+        c.instance_eval do
+          property :text, required: true
+        end
+
+        c.class_eval do
+          def text
+            "<em>#{super}</em>"
+          end
+        end
+      end
+    end
+
+    it "should raise an error during initilization if no value for :text has been specified" do
+      expect { klass.new }.to raise_error(SmartProperties::InitializationError)
+    end
+  end
+
   context 'when used to build a class that has a property called :id whose default value is a lambda statement for retrieving the object_id' do
     subject(:klass) do
       Class.new.tap do |c|


### PR DESCRIPTION
Raises an InitializationError if a required but overridden property has not been set (even if the overridden method returns a non-nil value).