### PR TITLE
Check for nil again after conversion

### DIFF
--- a/lib/smart_properties.rb
+++ b/lib/smart_properties.rb
@@ -156,6 +156,7 @@ module SmartProperties
     def prepare(value, scope)
       raise MissingValueError.new(scope, self) if required?(scope) && value.nil?
       value = convert(value, scope) unless value.nil?
+      raise MissingValueError.new(scope, self) if required?(scope) && value.nil?
       raise InvalidValueError.new(scope, self, value) unless accepts?(value, scope)
       value
     end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -51,6 +51,9 @@ RSpec.describe SmartProperties do
 
         expect { instance.title = nil }.to raise_error(exception, message, &further_expectations)
         expect { instance[:title] = nil }.to raise_error(exception, message, &further_expectations)
+
+        expect { instance.title = double(to_title: nil) }.to raise_error(exception, message, &further_expectations)
+        expect { instance[:title] = double(to_title: nil) }.to raise_error(exception, message, &further_expectations)
       end
 
       it "should not influence other instances that have been initialized with different attributes" do

--- a/spec/required_values_spec.rb
+++ b/spec/required_values_spec.rb
@@ -86,4 +86,19 @@ RSpec.describe SmartProperties do
       end
     end
   end
+
+  context "when building a class that has a required property with a default value and a malicious converter that always returns nil" do
+    subject(:klass) { DummyClass.new { property :title, required: true, converts: ->(_) { nil }, default: "Lorem Ipsum" } }
+
+    context 'an instance of this class' do
+      it "should raise an error when initialized" do
+        exception = SmartProperties::MissingValueError
+        message = "Dummy requires the property title to be set"
+        further_expectations = lambda { |error| expect(error.to_hash[:title]).to eq("must be set") }
+
+        expect { klass.new }.to raise_error(exception, message)
+        expect { klass.new(title: 'Lorem Ipsum') }.to raise_error(exception, message, &further_expectations)
+      end
+    end
+  end
 end


### PR DESCRIPTION
If a property is flagged as required, the converter must return a non-nil value.