### PR TITLE
Only convert if there is a converter

### DIFF
--- a/lib/smart_properties.rb
+++ b/lib/smart_properties.rb
@@ -155,7 +155,7 @@ module SmartProperties
 
     def prepare(value, scope)
       raise MissingValueError.new(scope, self) if required?(scope) && value.nil?
-      value = convert(value, scope) unless value.nil?
+      value = convert(value, scope) unless converter.nil? || value.nil?
       raise MissingValueError.new(scope, self) if required?(scope) && value.nil?
       raise InvalidValueError.new(scope, self, value) unless accepts?(value, scope)
       value


### PR DESCRIPTION
@t6d 

This gets around that issue we were running into, where we wanted to avoid calling `nil?` on the `value` if not absolutely necessary.

Note that the `convert` method already just returns if there's no converter: https://github.com/t6d/smart_properties/blob/7f04dd73270e7269f5a0cc3678c482688f45062b/lib/smart_properties.rb#L137.

For now, I just updated the problematic class in our private repo to not use `smart_properties` because this fix seems pretty fragile. But I figured I'd open a PR here to get your thoughts anyway.