### PR TITLE
Forwarding of unprocessed options

### DIFF
--- a/lib/smart_properties.rb
+++ b/lib/smart_properties.rb
@@ -108,13 +108,15 @@ module SmartProperties
   # @param [Hash] attrs the set of attributes that is used for initialization
   #
   def initialize(*args, &block)
-    attrs = args.last.is_a?(Hash) ? args.pop : {}
-    super(*args)
-
     properties = self.class.properties.to_hash
-    missing_properties = []
+
+    attrs = args.last.is_a?(Hash) ? args.pop : {}
+    attrs, opts = attrs.partition { |key, value| properties.key?(key) }.map { |array| Hash[array] }
+
+    opts.empty? ? super(*args) : super(*args.push(opts))
 
     # Set values
+    missing_properties = []
     properties.each do |name, property|
       if attrs.key?(name)
         property.set(self, attrs[name])

--- a/spec/inheritance_spec.rb
+++ b/spec/inheritance_spec.rb
@@ -17,9 +17,10 @@ RSpec.describe SmartProperties, 'intheritance' do
   context 'when modeling the following class hiearchy: Base > Section > SectionWithSubtitle' do
     let!(:base) do
       Class.new do
-        attr_reader :content
-        def initialize(content = nil)
+        attr_reader :content, :options
+        def initialize(content = nil, options = {})
           @content = content
+          @options = options
         end
       end
     end
@@ -48,6 +49,11 @@ RSpec.describe SmartProperties, 'intheritance' do
         subject { section.new }
         it { is_expected.to have_smart_property(:title) }
         it { is_expected.to_not have_smart_property(:subtitle) }
+
+        it 'should forward keyword arguments that do not correspond to a property to the super class constructor' do
+          instance = section.new('some content', answer: 42)
+          expect(instance.options).to eq({answer: 42})
+        end
       end
 
       context 'an instance of this class when initialized with content' do
@@ -90,6 +96,11 @@ RSpec.describe SmartProperties, 'intheritance' do
           expect(instance.title).to eq('some title')
           expect(instance.subtitle).to eq('some subtitle')
         end
+
+        it 'should forward keyword arguments that do not correspond to a property to the super class constructor' do
+          instance = subsection.new('some content', answer: 42)
+          expect(instance.options).to eq({answer: 42})
+        end
       end
     end
 
@@ -112,9 +123,10 @@ RSpec.describe SmartProperties, 'intheritance' do
       end
 
       context 'an instance of this class' do
-        subject(:instance) { subsection.new }
+        subject(:instance) { subsubsection.new }
         it { is_expected.to have_smart_property(:title) }
         it { is_expected.to have_smart_property(:subtitle) }
+        it { is_expected.to have_smart_property(:subsubtitle) }
 
         it 'should have content, a title, and a subtile when initialized with these parameters' do
           instance = subsubsection.new('some content', title: 'some title', subtitle: 'some subtitle', subsubtitle: 'some subsubtitle')
@@ -130,6 +142,11 @@ RSpec.describe SmartProperties, 'intheritance' do
           expect(instance.title).to eq('some title')
           expect(instance.subtitle).to eq('some subtitle')
           expect(instance.subsubtitle).to eq('some subsubtitle')
+        end
+
+        it 'should forward keyword arguments that do not correspond to a property to the super class constructor' do
+          instance = subsubsection.new('some content', answer: 42)
+          expect(instance.options).to eq({answer: 42})
         end
       end
     end


### PR DESCRIPTION
All keyword arguments that do not correspond to a property are forwarded to the super class constructor.