### PR TITLE
Revert "Forwarding of unprocessed options"

### DIFF
--- a/lib/smart_properties.rb
+++ b/lib/smart_properties.rb
@@ -108,15 +108,13 @@ module SmartProperties
   # @param [Hash] attrs the set of attributes that is used for initialization
   #
   def initialize(*args, &block)
-    properties = self.class.properties.to_hash
-
     attrs = args.last.is_a?(Hash) ? args.pop : {}
-    attrs, opts = attrs.partition { |key, value| properties.key?(key) }.map { |array| Hash[array] }
+    super(*args)
 
-    opts.empty? ? super(*args) : super(*args.push(opts))
+    properties = self.class.properties.to_hash
+    missing_properties = []
 
     # Set values
-    missing_properties = []
     properties.each do |name, property|
       if attrs.key?(name)
         property.set(self, attrs[name])

--- a/spec/inheritance_spec.rb
+++ b/spec/inheritance_spec.rb
@@ -17,10 +17,9 @@ RSpec.describe SmartProperties, 'intheritance' do
   context 'when modeling the following class hiearchy: Base > Section > SectionWithSubtitle' do
     let!(:base) do
       Class.new do
-        attr_reader :content, :options
-        def initialize(content = nil, options = {})
+        attr_reader :content
+        def initialize(content = nil)
           @content = content
-          @options = options
         end
       end
     end
@@ -49,11 +48,6 @@ RSpec.describe SmartProperties, 'intheritance' do
         subject { section.new }
         it { is_expected.to have_smart_property(:title) }
         it { is_expected.to_not have_smart_property(:subtitle) }
-
-        it 'should forward keyword arguments that do not correspond to a property to the super class constructor' do
-          instance = section.new('some content', answer: 42)
-          expect(instance.options).to eq({answer: 42})
-        end
       end
 
       context 'an instance of this class when initialized with content' do
@@ -96,11 +90,6 @@ RSpec.describe SmartProperties, 'intheritance' do
           expect(instance.title).to eq('some title')
           expect(instance.subtitle).to eq('some subtitle')
         end
-
-        it 'should forward keyword arguments that do not correspond to a property to the super class constructor' do
-          instance = subsection.new('some content', answer: 42)
-          expect(instance.options).to eq({answer: 42})
-        end
       end
     end
 
@@ -123,10 +112,9 @@ RSpec.describe SmartProperties, 'intheritance' do
       end
 
       context 'an instance of this class' do
-        subject(:instance) { subsubsection.new }
+        subject(:instance) { subsection.new }
         it { is_expected.to have_smart_property(:title) }
         it { is_expected.to have_smart_property(:subtitle) }
-        it { is_expected.to have_smart_property(:subsubtitle) }
 
         it 'should have content, a title, and a subtile when initialized with these parameters' do
           instance = subsubsection.new('some content', title: 'some title', subtitle: 'some subtitle', subsubtitle: 'some subsubtitle')
@@ -142,11 +130,6 @@ RSpec.describe SmartProperties, 'intheritance' do
           expect(instance.title).to eq('some title')
           expect(instance.subtitle).to eq('some subtitle')
           expect(instance.subsubtitle).to eq('some subsubtitle')
-        end
-
-        it 'should forward keyword arguments that do not correspond to a property to the super class constructor' do
-          instance = subsubsection.new('some content', answer: 42)
-          expect(instance.options).to eq({answer: 42})
         end
       end
     end


### PR DESCRIPTION
Reverts t6d/smart_properties#26 due to unforeseen issues with `HashWithIndifferentAccess` instances. These hashes return the `keys` as they were originally inserted and potentially break the `properties.key?` check in the initializer.

The better solution would be to use the property collection instead of a `to_hash` version of this collection. To make this work, the property collection needs to implement caching for performance reasons.