### PR TITLE
Proper PropertyCollection caching

### DIFF
--- a/smart_properties.gemspec
+++ b/smart_properties.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "rspec", "~> 3.0"
   gem.add_development_dependency "rake", "~> 10.0"
+  gem.add_development_dependency "pry"
 end

--- a/spec/property_collection_caching_spec.rb
+++ b/spec/property_collection_caching_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe SmartProperties, "property collection caching:" do
+  specify "SmartProperty enabled objects should be extendable at runtime" do
+    base_class = DummyClass.new { property :title }
+    subclass = DummyClass.new(base_class) { property :body }
+    subsubclass = DummyClass.new(subclass) { property :attachment }
+
+    expect(base_class.new).to have_smart_property(:title)
+    expect(subclass.new).to have_smart_property(:title)
+    expect(subclass.new).to have_smart_property(:body)
+
+    base_class.class_eval { property :severity }
+    expect(base_class.new).to have_smart_property(:severity)
+    expect(subclass.new).to have_smart_property(:severity)
+    expect(subsubclass.new).to have_smart_property(:severity)
+
+    expected_names = [:title, :body, :attachment, :severity]
+
+    names = subsubclass.properties.map(&:first) # Using enumerable
+    expect(names - expected_names).to be_empty
+
+    names = subsubclass.properties.each.map(&:first) # Using enumerator
+    expect(names - expected_names).to be_empty
+
+    expect(subsubclass.properties.keys - expected_names).to be_empty
+    expect(subsubclass.properties.to_hash.keys - expected_names).to be_empty
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'bundler/setup'
 require 'rspec'
+require 'pry'
 
 require 'smart_properties'
 


### PR DESCRIPTION
A PropertyCollection now keeps tracks of its children and updates them
whenever a new property is added to a class. This enables faster querying
for a particular property. Previously, this query would have caused walking
the entire PropertyCollection chain and merging several hashes.

Internally, a PropertyCollection references its properties using strings
because these are GCed. Assigning unsafe input to a SmartProperties enabled
object could otherwise lead to excisive memory usage because
PropertyCollection#key? would have to convert to a symbol which would not
be GCed.