### PR TITLE
Option Forwarding and Support for Strings as Keys

### DIFF
--- a/lib/smart_properties.rb
+++ b/lib/smart_properties.rb
@@ -108,34 +108,37 @@ module SmartProperties
   # @param [Hash] attrs the set of attributes that is used for initialization
   #
   def initialize(*args, &block)
-    properties = self.class.properties.to_hash
+    attrs = args.last.is_a?(Hash) ? args.pop.dup : {}
+    properties = self.class.properties
 
-    attrs = args.last.is_a?(Hash) ? args.pop : {}
-    attrs, opts = attrs.partition { |key, value| properties.key?(key) }.map { |array| Hash[array] }
-
-    opts.empty? ? super(*args) : super(*args.push(opts))
+    # Track missing properties
+    missing_properties = []
 
     # Set values
-    missing_properties = []
     properties.each do |name, property|
       if attrs.key?(name)
-        property.set(self, attrs[name])
+        property.set(self, attrs.delete(name))
+      elsif attrs.key?(name.to_s)
+        property.set(self, attrs.delete(name.to_s))
       else
         missing_properties.push(property)
       end
     end
 
+    # Call the super constructor and forward unprocessed arguments
+    attrs.empty? ? super(*args) : super(*args.push(attrs))
+
     # Execute configuration block
     block.call(self) if block
 
     # Set default values for missing properties
-    missing_properties.each { |property| property.set_default(self) }
+    missing_properties.delete_if { |property| property.set_default(self) }
 
-    # Check presence of all required properties
-    faulty_properties = properties.select { |_, property| property.missing?(self) }
-    unless faulty_properties.empty?
-      raise SmartProperties::InitializationError.new(self, faulty_properties.values)
-    end
+    # Recheck - cannot be done while assigning default values because
+    # one property might depend on the default value of another property
+    missing_properties.delete_if { |property| property.present?(self) || property.optional?(self) }
+
+    raise SmartProperties::InitializationError.new(self, missing_properties) unless missing_properties.empty?
   end
 end
 

--- a/lib/smart_properties.rb
+++ b/lib/smart_properties.rb
@@ -108,13 +108,15 @@ module SmartProperties
   # @param [Hash] attrs the set of attributes that is used for initialization
   #
   def initialize(*args, &block)
-    attrs = args.last.is_a?(Hash) ? args.pop : {}
-    super(*args)
-
     properties = self.class.properties.to_hash
-    missing_properties = []
+
+    attrs = args.last.is_a?(Hash) ? args.pop : {}
+    attrs, opts = attrs.partition { |key, value| properties.key?(key) }.map { |array| Hash[array] }
+
+    opts.empty? ? super(*args) : super(*args.push(opts))
 
     # Set values
+    missing_properties = []
     properties.each do |name, property|
       if attrs.key?(name)
         property.set(self, attrs[name])

--- a/lib/smart_properties/property.rb
+++ b/lib/smart_properties/property.rb
@@ -44,8 +44,16 @@ module SmartProperties
       @required.kind_of?(Proc) ? scope.instance_exec(&@required) : !!@required
     end
 
+    def optional?(scope)
+      !required?(scope)
+    end
+
     def missing?(scope)
-      required?(scope) && null_object?(get(scope))
+      required?(scope) && !present?(scope)
+    end
+
+    def present?(scope)
+      !null_object?(get(scope))
     end
 
     def convert(scope, value)
@@ -99,10 +107,13 @@ module SmartProperties
     end
 
     def set_default(scope)
-      if null_object?(get(scope))
-        default_value = default(scope)
-        set(scope, default_value) unless null_object?(default_value)
-      end
+      return false if present?(scope)
+
+      default_value = default(scope)
+      return false if null_object?(default_value)
+
+      set(scope, default_value)
+      true
     end
 
     def get(scope)

--- a/smart_properties.gemspec
+++ b/smart_properties.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "rspec", "~> 3.0"
   gem.add_development_dependency "rake", "~> 10.0"
+  gem.add_development_dependency "pry"
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -123,6 +123,13 @@ RSpec.describe SmartProperties do
         expect(instance.title).to eq('bacon')
         expect(instance[:title]).to eq('bacon')
       end
+
+      it "should have the title specified in the corresponding attributes hash that uses strings as keys" do
+        attributes = {"title" => double(to_title: 'bacon')}
+        instance = klass.new(attributes)
+        expect(instance.title).to eq('bacon')
+        expect(instance[:title]).to eq('bacon')
+      end
     end
 
     context "an instance of this class when initialized with a block" do

--- a/spec/inheritance_spec.rb
+++ b/spec/inheritance_spec.rb
@@ -144,6 +144,16 @@ RSpec.describe SmartProperties, 'intheritance' do
           expect(instance.subsubtitle).to eq('some subsubtitle')
         end
 
+        it 'should not accidentally forward attributes as options because the keys where strings' do
+          attributes = {'title' => 'some title', 'subtitle' => 'some subtitle', 'subsubtitle' => "some subsubtitle", "answer" => 42}
+          instance = subsubsection.new('some content', attributes)
+          expect(instance.content).to eq('some content')
+          expect(instance.title).to eq('some title')
+          expect(instance.subtitle).to eq('some subtitle')
+          expect(instance.subsubtitle).to eq('some subsubtitle')
+          expect(instance.options).to eq({"answer" => 42})
+        end
+
         it 'should forward keyword arguments that do not correspond to a property to the super class constructor' do
           instance = subsubsection.new('some content', answer: 42)
           expect(instance.options).to eq({answer: 42})

--- a/spec/inheritance_spec.rb
+++ b/spec/inheritance_spec.rb
@@ -17,9 +17,10 @@ RSpec.describe SmartProperties, 'intheritance' do
   context 'when modeling the following class hiearchy: Base > Section > SectionWithSubtitle' do
     let!(:base) do
       Class.new do
-        attr_reader :content
-        def initialize(content = nil)
+        attr_reader :content, :options
+        def initialize(content = nil, options = {})
           @content = content
+          @options = options
         end
       end
     end
@@ -48,6 +49,11 @@ RSpec.describe SmartProperties, 'intheritance' do
         subject { section.new }
         it { is_expected.to have_smart_property(:title) }
         it { is_expected.to_not have_smart_property(:subtitle) }
+
+        it 'should forward keyword arguments that do not correspond to a property to the super class constructor' do
+          instance = section.new('some content', answer: 42)
+          expect(instance.options).to eq({answer: 42})
+        end
       end
 
       context 'an instance of this class when initialized with content' do
@@ -90,6 +96,11 @@ RSpec.describe SmartProperties, 'intheritance' do
           expect(instance.title).to eq('some title')
           expect(instance.subtitle).to eq('some subtitle')
         end
+
+        it 'should forward keyword arguments that do not correspond to a property to the super class constructor' do
+          instance = subsection.new('some content', answer: 42)
+          expect(instance.options).to eq({answer: 42})
+        end
       end
     end
 
@@ -112,9 +123,10 @@ RSpec.describe SmartProperties, 'intheritance' do
       end
 
       context 'an instance of this class' do
-        subject(:instance) { subsection.new }
+        subject(:instance) { subsubsection.new }
         it { is_expected.to have_smart_property(:title) }
         it { is_expected.to have_smart_property(:subtitle) }
+        it { is_expected.to have_smart_property(:subsubtitle) }
 
         it 'should have content, a title, and a subtile when initialized with these parameters' do
           instance = subsubsection.new('some content', title: 'some title', subtitle: 'some subtitle', subsubtitle: 'some subsubtitle')
@@ -130,6 +142,11 @@ RSpec.describe SmartProperties, 'intheritance' do
           expect(instance.title).to eq('some title')
           expect(instance.subtitle).to eq('some subtitle')
           expect(instance.subsubtitle).to eq('some subsubtitle')
+        end
+
+        it 'should forward keyword arguments that do not correspond to a property to the super class constructor' do
+          instance = subsubsection.new('some content', answer: 42)
+          expect(instance.options).to eq({answer: 42})
         end
       end
     end

--- a/spec/property_collection_caching_spec.rb
+++ b/spec/property_collection_caching_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe SmartProperties, "property collection caching:" do
+  specify "SmartProperty enabled objects should be extendable at runtime" do
+    base_class = DummyClass.new { property :title }
+    subclass = DummyClass.new(base_class) { property :body }
+    subsubclass = DummyClass.new(subclass) { property :attachment }
+
+    expect(base_class.new).to have_smart_property(:title)
+    expect(subclass.new).to have_smart_property(:title)
+    expect(subclass.new).to have_smart_property(:body)
+
+    base_class.class_eval { property :severity }
+    expect(base_class.new).to have_smart_property(:severity)
+    expect(subclass.new).to have_smart_property(:severity)
+    expect(subsubclass.new).to have_smart_property(:severity)
+
+    expected_names = [:title, :body, :attachment, :severity]
+
+    names = subsubclass.properties.map(&:first) # Using enumerable
+    expect(names - expected_names).to be_empty
+
+    names = subsubclass.properties.each.map(&:first) # Using enumerator
+    expect(names - expected_names).to be_empty
+
+    expect(subsubclass.properties.keys - expected_names).to be_empty
+    expect(subsubclass.properties.to_hash.keys - expected_names).to be_empty
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'bundler/setup'
 require 'rspec'
+require 'pry'
 
 require 'smart_properties'
 


### PR DESCRIPTION
Improvements:
* `SmartProperties` enabled objects can now be intialized with hashes that use strings as keys.
* All keyword arguments that do not correspond to a property are now forwarded to the super class constructor.
* The performance of the initializer has been improved by reducing the number of instantiated helper objects.