### PR TITLE
Enable `accepts: Boolean` syntax

### DIFF
--- a/lib/smart_properties.rb
+++ b/lib/smart_properties.rb
@@ -96,6 +96,9 @@ module SmartProperties
     #
     def included(base)
       base.extend(ClassMethods)
+
+      # Allows `accepts: Boolean` syntax.
+      base.superclass.send(:const_set, "Boolean", [true, false])
     end
   end
 

--- a/spec/support/dummy_class.rb
+++ b/spec/support/dummy_class.rb
@@ -6,4 +6,3 @@ class << (DummyClass = BasicObject.new)
     c
   end
 end
-


### PR DESCRIPTION
Currently we need to write following code to get validation for a boolean value for a property:

``` Ruby
property :title, accepts: String
property :price, accepts: Integer
property :new, accepts: [true, false]
```

By injecting a constant `Boolean` with the values `[true, false]` we can enable following syntax:

``` Ruby
property :title, accepts: String
property :price, accepts: Integer
property :new, accepts: Boolean
```
