### PR TITLE
Add property! method for required arguments

### DIFF
--- a/lib/smart_properties.rb
+++ b/lib/smart_properties.rb
@@ -83,6 +83,12 @@ module SmartProperties
       properties[name] = Property.define(self, name, options)
     end
     protected :property
+
+    def property!(name, options = {})
+      options[:required] = true
+      property(name, options)
+    end
+    protected :property!
   end
 
   class << self


### PR DESCRIPTION
Closes https://github.com/t6d/smart_properties/issues/49

Add a `property!` method to require arguments.

CC: @t6d 