### PR TITLE
Add property! method to define required arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ class Article
 end
 ```
 
-Alternatively you can also use the `property!` method .
+Alternatively you can also use the `property!` method.
 
 ```ruby
 class Article

--- a/README.md
+++ b/README.md
@@ -200,6 +200,14 @@ class Article
 end
 ```
 
+Alternatively you can also use the `property!` method .
+
+```ruby
+class Article
+  property! :title
+end
+```
+
 The decision whether or not a property is required can also be delayed and
 evaluated at runtime by providing a block instead of a boolean value. The
 example below shows how to implement a class that has two properties, `name`

--- a/lib/smart_properties.rb
+++ b/lib/smart_properties.rb
@@ -83,6 +83,12 @@ module SmartProperties
       properties[name] = Property.define(self, name, options)
     end
     protected :property
+
+    def property!(name, options = {})
+      options[:required] = true
+      property(name, options)
+    end
+    protected :property!
   end
 
   class << self


### PR DESCRIPTION
Closes https://github.com/t6d/smart_properties/issues/49

Add alternative notation `property!` method to define required arguments.

CC: @t6d 