### PR TITLE
ConstructorArgumentForwardingError

### DIFF
--- a/lib/smart_properties/errors.rb
+++ b/lib/smart_properties/errors.rb
@@ -13,6 +13,35 @@ module SmartProperties
     end
   end
 
+  class ConstructorArgumentForwardingError < Error
+    def initialize(positional_arguments, keyword_arguments)
+      argument_description = [
+        generate_description("positional", positional_arguments.count),
+        generate_description("keyword", keyword_arguments.count)
+      ].compact
+
+      arguments = positional_arguments + keyword_arguments.map { |name, value| "#{name}: #{value}" }
+
+      super "Forwarding the following %s failed: %s" % [
+        argument_description.join(" and "),
+        arguments.join(", ")
+      ]
+    end
+
+    private
+
+    def generate_description(argument_type, argument_number)
+      case argument_number
+      when 0
+        nil
+      when 1
+        "#{argument_type} argument"
+      else
+        "#{argument_number} #{argument_type} arguments"
+      end
+    end
+  end
+
   class MissingValueError < AssignmentError
     def initialize(sender, property)
       super(

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -19,6 +19,21 @@ RSpec.describe SmartProperties do
         expect { instance = klass.new(title: BasicObject) }.to_not raise_error
       end
     end
+
+    context "the initializer" do
+      it "should raise an ConstructorArgumentForwardingError if provided with an additional positional argument" do
+        unexpected_argument = double("unexpected argument")
+        expect { klass.new(unexpected_argument) }
+          .to raise_error(SmartProperties::ConstructorArgumentForwardingError, /Forwarding the following positional argument failed:.*unexpected argument.*/)
+      end
+
+      it "should raise an ConstructorArgumentForwardingError if provided with unknown keyword arguments" do
+        unexpected_argument1 = double("unexpected argument")
+        unexpected_argument2 = double("unexpected argument")
+        expect { klass.new(first_arg: unexpected_argument1, second_arg: unexpected_argument2) }
+            .to raise_error(SmartProperties::ConstructorArgumentForwardingError, /Forwarding the following 2 keyword arguments failed: first_arg: .*unexpected argument.*, second_arg: .*unexpected argument.*/)
+      end
+    end
   end
 
   context "when used to build a class that has a property called title that utilizes the full feature set of SmartProperties" do


### PR DESCRIPTION
Introduces a new error: ConstructorArgumentForwardingError. This error gets raised when positional arguments or unknown additional keyword arguments get forwarded to the super class initializer which itself can’t process them.

FYI, @SebastianSzturo