### PR TITLE
Use equality test for nil as a last resort

### DIFF
--- a/lib/smart_properties/property.rb
+++ b/lib/smart_properties/property.rb
@@ -137,9 +137,7 @@ module SmartProperties
     private
 
     def null_object?(object)
-      return true if object == nil
-      return true if object.nil?
-      false
+      object.nil?
     rescue NoMethodError => error
       # BasicObject does not respond to #nil? by default, so we need to double
       # check if somebody implemented it and it fails internally or if the

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -164,4 +164,34 @@ RSpec.describe SmartProperties do
       end
     end
   end
+
+  context "when used to build a class that has a property called relation for an arbitrary Relation class" do
+    class Relation
+      attr_reader :equality_tested
+
+      def initialize
+        @equality_tested = false
+      end
+
+      def ==(_)
+        @equality_tested = true
+        false
+      end
+    end
+
+    subject(:klass) do
+      DummyClass.new do
+        property :relation, accepts: Relation, required: true
+      end
+    end
+
+    context 'with an instance of Relation' do
+      let(:relation) { Relation.new }
+
+      it 'should not execute #== on the object' do
+        instance = klass.new(relation: relation)
+        expect(relation.equality_tested).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
I ran into an issue when using properties that are ActiveRecord::Relation objects - essentially what was happening was extra queries being made to the database during smart property validation. It turns out that ActiveRecord (and probably other things) can have side effects when using the built-in equality methods.

This PR changes the order of the nil-checking for properties and uses the `#nil?` method as the default now; if a `NoMethodError` is raised, then we can safely do a nil singleton equality check since the object being validated is most likely descending from BasicObject.