### PR TITLE
Fixing PropertyCollection to deal with prepended modules

### DIFF
--- a/lib/smart_properties/property_collection.rb
+++ b/lib/smart_properties/property_collection.rb
@@ -6,7 +6,9 @@ module SmartProperties
 
     def self.for(scope)
       parent = scope.ancestors[1..-1].find do |ancestor|
-        ancestor.ancestors.include?(SmartProperties) && ancestor != SmartProperties
+        ancestor.ancestors.include?(SmartProperties) &&
+          ancestor != scope &&
+          ancestor != SmartProperties
       end
 
       if parent.nil?

--- a/spec/property_collection_caching_spec.rb
+++ b/spec/property_collection_caching_spec.rb
@@ -26,4 +26,14 @@ RSpec.describe SmartProperties, "property collection caching:" do
     expect(subsubclass.properties.keys - expected_names).to be_empty
     expect(subsubclass.properties.to_hash.keys - expected_names).to be_empty
   end
+
+  specify "a SmartProperty enabled object should not check itself for properties if prepended" do
+    expect do
+      base_class = DummyClass.new {
+        prepend Module.new
+        property :title
+      }
+      expect(base_class.new).to have_smart_property(:title)
+    end.not_to raise_error(SystemStackError)
+  end
 end


### PR DESCRIPTION
There is an issue when prepending a module to a class that has`SmartProperties`. When `SmartProperties::PropertyCollection.for` is called, it will identify the class as a parent of itself. This
will cause a recursive ancestor check.

To fix this, I added a simple check in the parent identification to ensure that the ancestor is not the base class.