### PR TITLE
Adding writable as an option on property.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea/
 
 .rspec
 .rvmrc

--- a/lib/smart_properties/property.rb
+++ b/lib/smart_properties/property.rb
@@ -7,7 +7,7 @@ module SmartProperties
     attr_reader :accepter
     attr_reader :reader
     attr_reader :instance_variable_name
-    attr_reader :read_only
+    attr_reader :writable
 
     def self.define(scope, name, options = {})
       new(name, options).tap { |p| p.define(scope) }
@@ -22,7 +22,7 @@ module SmartProperties
       @accepter  = attrs.delete(:accepts)
       @required  = attrs.delete(:required)
       @reader    = attrs.delete(:reader)
-      @read_only = attrs.delete(:read_only)
+      @writable  = attrs.delete(:writable)
       @reader    ||= @name
 
       @instance_variable_name = :"@#{name}"
@@ -46,10 +46,6 @@ module SmartProperties
 
     def present?(scope)
       !null_object?(get(scope))
-    end
-
-    def allow_write?
-      !read_only
     end
 
     def convert(scope, value)
@@ -105,7 +101,7 @@ module SmartProperties
         property.get(self)
       end
 
-      if allow_write?
+      if writable
         scope.send(:define_method, :"#{name}=") do |value|
           property.set(self, value)
         end

--- a/lib/smart_properties/property.rb
+++ b/lib/smart_properties/property.rb
@@ -48,6 +48,11 @@ module SmartProperties
       !null_object?(get(scope))
     end
 
+    def writable?
+      return true if @writable.nil?
+      @writable
+    end
+
     def convert(scope, value)
       return value unless converter
       return value if null_object?(value)
@@ -101,7 +106,7 @@ module SmartProperties
         property.get(self)
       end
 
-      if writable
+      if writable?
         scope.send(:define_method, :"#{name}=") do |value|
           property.set(self, value)
         end

--- a/spec/read_only_spec.rb
+++ b/spec/read_only_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SmartProperties, 'read only properties' do
+  context 'when a property is defined as read_only there should be no accessor for the property' do
+    subject(:klass) { DummyClass.new { property :id, read_only: true } }
+
+    it "should throw a no method error when trying to set the property" do
+      new_class_instance = klass.new(id: 42)
+
+      expect(new_class_instance.id).to eq(42)
+      expect { new_class_instance.id = 50 }.to raise_error(NoMethodError)
+      expect(new_class_instance.id).to eq(42)
+    end
+  end
+
+  context 'when a property is defined as not read_only there should be an accessor available' do
+    subject(:klass) { DummyClass.new { property :id, read_only: false } }
+
+    it "should allow changing of the property" do
+      new_class_instance = klass.new(id: 42)
+
+      new_class_instance.id = 50
+      expect(new_class_instance.id).to eq(50)
+    end
+  end
+
+  context 'when read_only is not defined on the property it should default to being writable' do
+    subject(:klass) { DummyClass.new { property :id } }
+
+    it "should allow changing of the property" do
+      new_class_instance = klass.new(id: 42)
+
+      new_class_instance.id = 50
+      expect(new_class_instance.id).to eq(50)
+    end
+  end
+end

--- a/spec/writable_spec.rb
+++ b/spec/writable_spec.rb
@@ -2,9 +2,9 @@
 
 require 'spec_helper'
 
-RSpec.describe SmartProperties, 'read only properties' do
-  context 'when a property is defined as read_only there should be no accessor for the property' do
-    subject(:klass) { DummyClass.new { property :id, read_only: true } }
+RSpec.describe SmartProperties, 'writable properties' do
+  context 'when a property is defined as not writable there should be no accessor for the property' do
+    subject(:klass) { DummyClass.new { property :id, writable: false } }
 
     it "should throw a no method error when trying to set the property" do
       new_class_instance = klass.new(id: 42)
@@ -15,8 +15,8 @@ RSpec.describe SmartProperties, 'read only properties' do
     end
   end
 
-  context 'when a property is defined as not read_only there should be an accessor available' do
-    subject(:klass) { DummyClass.new { property :id, read_only: false } }
+  context 'when a property is defined as writable there should be an accessor available' do
+    subject(:klass) { DummyClass.new { property :id, writable: true } }
 
     it "should allow changing of the property" do
       new_class_instance = klass.new(id: 42)
@@ -26,7 +26,7 @@ RSpec.describe SmartProperties, 'read only properties' do
     end
   end
 
-  context 'when read_only is not defined on the property it should default to being writable' do
+  context 'when writable is not defined on the property it should default to being writable' do
     subject(:klass) { DummyClass.new { property :id } }
 
     it "should allow changing of the property" do


### PR DESCRIPTION
By default `property` creates both an accessor and a reader for the property.
Currently if you do not want a public accessor you have to do something similar to the following:
```ruby
class TestClass
  property! :id
  protected :id=
end
```

This proposed change allows the ability to make a property read only:
```ruby
class TestClass
  property! :id, read_only: true
end
```
When using the `read_only` flag as `true` an accessor will not be created for that property.
If no `read_only` flag is provided the current default behaviour of creating an accessor will continue.