### PR TITLE
Add metadata for the source code

### DIFF
--- a/smart_properties.gemspec
+++ b/smart_properties.gemspec
@@ -12,6 +12,10 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{SmartProperties – Ruby accessors on steroids}
   gem.homepage      = ""
 
+  gem.metadata = {
+    "source_code_uri" => "https://github.com/t6d/smart_properties"
+  }
+
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
By doing this, automated tools like dependabot can now find the repository based on the gem.