### PR TITLE
Prevent defaults that may be shared and mutated across all instances of a class

### DIFF
--- a/lib/smart_properties/property.rb
+++ b/lib/smart_properties/property.rb
@@ -1,6 +1,7 @@
 module SmartProperties
   class Property
     MODULE_REFERENCE = :"@_smart_properties_method_scope"
+    ALLOWED_DEFAULT_CLASSES = [Proc, Numeric, String, Range, TrueClass, FalseClass, NilClass, Symbol].freeze
 
     attr_reader :name
     attr_reader :converter
@@ -26,6 +27,11 @@ module SmartProperties
       @reader    ||= @name
 
       @instance_variable_name = :"@#{name}"
+
+      unless ALLOWED_DEFAULT_CLASSES.any? { |cls| @default.is_a?(cls) }
+        raise ConfigurationError, "Default attribute value #{@default.inspect} cannot be specified as literal, "\
+          "use the syntax `default: -> { ... }` instead."
+      end
 
       unless attrs.empty?
         raise ConfigurationError, "SmartProperties do not support the following configuration options: #{attrs.keys.map { |m| m.to_s }.sort.join(', ')}."
@@ -66,7 +72,7 @@ module SmartProperties
     end
 
     def default(scope)
-      @default.kind_of?(Proc) ? scope.instance_exec(&@default) : @default
+      @default.kind_of?(Proc) ? scope.instance_exec(&@default) : @default.dup
     end
 
     def accepts?(value, scope)

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe SmartProperties do
       default_title = double(to_title: 'chunky')
 
       DummyClass.new do
-        property :title, converts: :to_title, accepts: String, required: true, default: default_title
+        property :title, converts: :to_title, accepts: String, required: true, default: -> { default_title }
       end
     end
 
@@ -49,7 +49,7 @@ RSpec.describe SmartProperties do
 
     it "should return a property's configuration with #to_h" do
       expect(klass.properties.values.first.to_h).to match(
-        accepter: String, converter: :to_title, default: an_instance_of(RSpec::Mocks::Double),
+        accepter: String, converter: :to_title, default: an_instance_of(Proc),
         instance_variable_name: :@title, name: :title, reader: :title, required: true
       )
     end

--- a/spec/configuration_error_spec.rb
+++ b/spec/configuration_error_spec.rb
@@ -13,5 +13,19 @@ RSpec.describe SmartProperties, 'configuration error' do
 
       expect(&invalid_property_definition).to raise_error(SmartProperties::ConfigurationError, "SmartProperties do not support the following configuration options: invalid_option_1, invalid_option_2, invalid_option_3.")
     end
+
+    it "should not accept default values that may be mutated" do
+      invalid_property_definition = lambda do
+        klass.class_eval do
+          property :title, default: []
+        end
+      end
+
+      expect(&invalid_property_definition).to(
+        raise_error(SmartProperties::ConfigurationError,
+          "Default attribute value [] cannot be specified as literal, "\
+            "use the syntax `default: -> { ... }` instead.")
+      )
+    end
   end
 end

--- a/spec/default_values_spec.rb
+++ b/spec/default_values_spec.rb
@@ -48,4 +48,72 @@ RSpec.describe SmartProperties, 'default values' do
       end
     end
   end
+
+  context "when defining a new property with a literal default value" do
+    context 'with a numeric default' do
+      subject(:klass) { DummyClass.new { property :var, default: 123 } }
+
+      it 'accepts the default and returns it' do
+        instance = klass.new
+        expect(instance.var).to(be(123))
+      end
+    end
+
+    context 'with a string default' do
+      DEFAULT_VALUE = 'a string'
+      subject(:klass) { DummyClass.new { property :var, default: DEFAULT_VALUE } }
+
+      it 'accepts the default and returns it' do
+        instance = klass.new
+        expect(instance.var).to(eq(DEFAULT_VALUE))
+      end
+
+      it 'returns a copy of the string' do
+        instance = klass.new
+        expect(instance.var).to_not(be(DEFAULT_VALUE))
+      end
+
+      it 'mutating the instance variable does not mutate the original' do
+        instance = klass.new
+        instance.var[0] = 'o'
+        expect(DEFAULT_VALUE).to(eq('a string'))
+      end
+    end
+
+    context 'with a range default' do
+      subject(:klass) { DummyClass.new { property :var, default: 1..2 } }
+
+      it 'accepts the default and returns it' do
+        instance = klass.new
+        expect(instance.var).to(eq(1..2))
+      end
+    end
+
+    context 'with a true default' do
+      subject(:klass) { DummyClass.new { property :var, default: true } }
+
+      it 'accepts the default and returns it' do
+        instance = klass.new
+        expect(instance.var).to(be(true))
+      end
+    end
+
+    context 'with a false default' do
+      subject(:klass) { DummyClass.new { property :var, default: false } }
+
+      it 'accepts the default and returns it' do
+        instance = klass.new
+        expect(instance.var).to(be(false))
+      end
+    end
+
+    context 'with a symbol default' do
+      subject(:klass) { DummyClass.new { property :var, default: :foo } }
+
+      it 'accepts the default and returns it' do
+        instance = klass.new
+        expect(instance.var).to(be(:foo))
+      end
+    end
+  end
 end


### PR DESCRIPTION
I encountered an issue where a property with a default specified as `default: []` ends up being shared across all instances of the class where the property is defined. Adding elements to the array is reflected across other instances since the array is shared.

For example this would be the current behavior without this PR:

```ruby
class Foo
  include SmartProperties
  property :array,  default: []
end

a = Foo.new
b = Foo.new

a.array << 1

# shows the bug:
puts b.array # => [1]

# they are in fact the same:
puts b.array.object_id == a.array.object_id # => true
```

Likewise, this is possible:
```ruby
class Foo
  include SmartProperties
  property :string,  default: 'foo!'
end

a = Foo.new
b = Foo.new

a.string[0] = 'z'
puts b.string # => zoo!

a.string << 'moo'
puts b.string # => zoo!moo
```

These may be more common than we realize since the `default: []` and `default: 'foo'` syntax don't appear very dangerous to developers who don't realize how default values work.

To fix the issue I added:
1) A check that prevent anything other than simple literals from being used without the Proc syntax.
2) A `.dup` when returning the default value that will prevent string literals from being mutated across instances.