### PR TITLE
Patch for dup Symbols (Ruby 2.2.3)

### DIFF
--- a/lib/smart_properties/property.rb
+++ b/lib/smart_properties/property.rb
@@ -72,7 +72,11 @@ module SmartProperties
     end
 
     def default(scope)
-      @default.kind_of?(Proc) ? scope.instance_exec(&@default) : @default.dup
+      return scope.instance_exec(&@default) if @default.kind_of?(Proc)
+      return @default.dup unless @default.respond_to?(:duplicable?)
+
+      return @default.dup if @default.duplicable?
+      @default
     end
 
     def accepts?(value, scope)


### PR DESCRIPTION
## Background

We are using smart_properties (through the gem [`active_operation`](https://github.com/t6d/active_operation)) in our legacy Ruby on Rails application. This app uses an older version of Ruby, `2.2.3`. Unfortunately, it is not a possibility to upgrade to Ruby 2.4.

An error `TypeError: can't dup Symbol` was being triggered because when initializing a property, the `default` attribute is a initialized with a `Symbol` in `active_operation` (like you can see at this line [here](https://github.com/t6d/active_operation/blob/71e0eb064fe461c0f41a70eadbad1cfc59c6d4a6/lib/active_operation/base.rb#L10)).

Until I believe Ruby v2.4, `Symbol`s cannot be duplicated which throws this type error. On more recent applications, this error obviously does not get triggered.

This is not only true for Symbols, but also applies to `NilClass`, `True/FalseClass`, `Numeric`, `BigDecimal`, and `Method`.

## Solution

If the property's `default` attribute is a Symbol, return it, don't `dup` it.
The behaviour will not change if `default` is a proc and supports `dup`.

Rails gives the `duplicable?` method for free to check if the object can be `dup`'ed. If this is defined (ie: if we are using Rails), we check if the object can be duplicated and we duplicate it. If `duplicable?` is not defined, then we return `default.dup`

The goal here is to preserve the exact behaviour just by adding some protection for those who want to use this gem with older versions of Ruby (on Rails).

### Alternatives

Instead of writing `@default && @default.dup`, we wanted to write `@default&.dup` but the safe navigation operator is not available until Ruby 2.3 either.

## Quality code checking

- [x] I have checked that my code is bug-free
- [x] My code is backwards-compatible
- [x] All specs are clear