### PR TITLE
Add missing keyword to Ancestor.must_be

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ often. These validations can be found in the `SmartProperties::Validations` modu
 
 ```ruby
 class Article
-  property :view_count, accepts: Ancestor.must_be(Number)
+  property :view_count, accepts: Ancestor.must_be(type: Number)
 end
 ```
 


### PR DESCRIPTION
```ruby
Ancestor.must_be(Numeric)
```

fails with:

```
Forwarding the following positional argument failed: Numeric
```

You need the `type:` keyword label.