### PR TITLE
Allow Modules (and classes) as default values

### DIFF
--- a/lib/smart_properties/property.rb
+++ b/lib/smart_properties/property.rb
@@ -1,7 +1,7 @@
 module SmartProperties
   class Property
     MODULE_REFERENCE = :"@_smart_properties_method_scope"
-    ALLOWED_DEFAULT_CLASSES = [Proc, Numeric, String, Range, TrueClass, FalseClass, NilClass, Symbol].freeze
+    ALLOWED_DEFAULT_CLASSES = [Proc, Numeric, String, Range, TrueClass, FalseClass, NilClass, Symbol, Module].freeze
 
     attr_reader :name
     attr_reader :converter

--- a/spec/configuration_error_spec.rb
+++ b/spec/configuration_error_spec.rb
@@ -14,6 +14,25 @@ RSpec.describe SmartProperties, 'configuration error' do
       expect(&invalid_property_definition).to raise_error(SmartProperties::ConfigurationError, "SmartProperties do not support the following configuration options: invalid_option_1, invalid_option_2, invalid_option_3.")
     end
 
+    it "should accept default values that can't be mutated" do
+      valid_property_definition = lambda do
+        klass.class_eval do
+          property :proc, default: -> { }
+          property :numeric_float, default: 1.23
+          property :numeric_int, default: 456
+          property :string, default: "abc"
+          property :range, default: 123...456
+          property :bool_true, default: true
+          property :bool_false, default: false
+          property :nil, default: nil
+          property :symbol, default: :abc
+          property :module, default: Integer
+        end
+      end
+
+      expect(&valid_property_definition).not_to raise_error
+    end
+
     it "should not accept default values that may be mutated" do
       invalid_property_definition = lambda do
         klass.class_eval do


### PR DESCRIPTION
Previously, these needed to be wrapped in a Proc, but it was pointless since
modules/classes are shared mutable state that's always intentionally shared/aliased.

This allows you to rewrite:

```ruby
property :strategy, accept: Ancestor.must_be(type: BaseStrategy), default: -> { DefaultStrategy }
```

... as just:

```
property :strategy, accept: Ancestor.must_be(type: BaseStrategy), default: DefaultStrategy
```