### PR TITLE
SmartProperties::Plugin

### DIFF
--- a/lib/smart_properties.rb
+++ b/lib/smart_properties.rb
@@ -9,8 +9,7 @@ define_method(:SmartProperties, &Class.new(Module) do
   end
 
   def included(base)
-    base.extend(SmartProperties::DSL)
-    plugins.each { |plugin| base.include(plugin) }
+    [SmartProperties::DSL, *plugins].each { |plugin| plugin.attach(base) }
   end
 
   def inspect
@@ -59,6 +58,7 @@ SmartProperties = SmartProperties(-> { SmartProperties::Initializer }, -> { Smar
 #
 module SmartProperties; end
 
+require_relative 'smart_properties/plugin'
 require_relative 'smart_properties/dsl'
 require_relative 'smart_properties/generic_accessors'
 require_relative 'smart_properties/initializer'

--- a/lib/smart_properties/dsl.rb
+++ b/lib/smart_properties/dsl.rb
@@ -1,5 +1,5 @@
 module SmartProperties
-  module DSL
+  DSL = SmartProperties::Plugin.new(:extend) do
     ##
     # Returns a class's smart properties. This includes the properties that
     # have been defined in the parent classes.

--- a/lib/smart_properties/generic_accessors.rb
+++ b/lib/smart_properties/generic_accessors.rb
@@ -1,5 +1,5 @@
 module SmartProperties
-  module GenericAccessors
+  GenericAccessors = SmartProperties::Plugin.new(:include) do
     def [](name)
       return if name.nil?
       name = name.to_sym

--- a/lib/smart_properties/initializer.rb
+++ b/lib/smart_properties/initializer.rb
@@ -1,5 +1,5 @@
 module SmartProperties
-  module Initializer
+  Initializer = SmartProperties::Plugin.new(:include) do
     ##
     # Implements a key-value enabled constructor that acts as default
     # constructor for all {SmartProperties}-enabled classes. Positional arguments

--- a/lib/smart_properties/plugin.rb
+++ b/lib/smart_properties/plugin.rb
@@ -1,0 +1,15 @@
+module SmartProperties
+  class Plugin < Module
+    attr_reader :type
+
+    def initialize(type, &block)
+      raise ArgumentError, "Unkown plugin type" unless [:include, :extend].include?(type)
+      @type = type
+      super(&block)
+    end
+
+    def attach(target_class)
+      target_class.send(type, self)
+    end
+  end
+end

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe SmartProperties::Plugin do
+  subject(:plugin) { SmartProperties::Plugin }
+  let(:target_class) { Class.new }
+
+  it "create a module" do
+    expect(plugin.new(:include)).to be_kind_of(Module)
+  end
+
+  it "can be instantiated and included into a class through #attach" do
+    plugin
+      .new(:include) { def hello; end }
+      .attach(target_class)
+
+    expect(target_class.new).to respond_to(:hello)
+  end
+
+  it "can be instantiated and extend a class through #attach" do
+    plugin
+      .new(:extend) { def hello; end }
+      .attach(target_class)
+
+    expect(target_class).to respond_to(:hello)
+  end
+
+  it "raises if an invalid type is passed to .new" do
+    expect { plugin.new(:unknown) }.to raise_error(ArgumentError)
+  end
+end


### PR DESCRIPTION
Introduces a subclass of Module named `SmartProperties::Plugin` that enables the creation of plugins that know whether they need to include themselves or extend the target class.

```ruby
HelloPlugin = SmartProperties::Plugin.new(:include) do
  def hello
    "hello"
  end
end

SomeClass = Class.new
HelloPlugin.attach(SomeClass)
HelloPlugin.new.hello # => "hello"
```

Co-authored-by: Vivek Wassan <vivek.wassan@shopify.com>