### PR TITLE
Argument forwarding for generic accessors

### DIFF
--- a/lib/smart_properties/plugins/generic_accessors.rb
+++ b/lib/smart_properties/plugins/generic_accessors.rb
@@ -3,14 +3,13 @@ module SmartProperties
     GenericAccessors = SmartProperties::Plugin.new(:include) do
       def [](name)
         return if name.nil?
-        name = name.to_sym
-        reader = self.class.properties[name].reader
-        public_send(reader) if self.class.properties.key?(name)
+        reader = self.class.properties[name.to_sym]&.reader
+        reader ?  public_send(reader) : super
       end
 
       def []=(name, value)
         return if name.nil?
-        public_send(:"#{name.to_sym}=", value) if self.class.properties.key?(name)
+        self.class.properties.key?(name) ? public_send(:"#{name.to_sym}=", value) : super
       end
     end
   end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -98,6 +98,34 @@ RSpec.describe SmartProperties do
         expect(instance.title).to eq('chunky')
         expect(other_instance.title).to eq('Lorem ipsum')
       end
+
+      it "should forward calls to #[] to its super class when the property is not known" do
+        super_klass = Class.new do
+          def [](key)
+            return "chunky" if key == "bacon"
+            raise KeyError, "Unknown key: #{key}"
+          end
+        end
+
+        klass = Class.new(super_klass) do
+          include SmartProperties
+        end
+
+        expect(klass.new["bacon"]).to eq("chunky")
+      end
+
+      it "should forward calls to #[]= to its super class when the property is not known" do
+        klass = Class.new(Hash) do
+          include SmartProperties
+          property :meal, converts: :upcase
+        end
+
+        instance = klass.new
+        instance[:bacon] = "chunky"
+        instance[:meal] = "breakfast"
+        expect(instance[:bacon]).to eq("chunky")
+        expect(instance[:meal]).to eq("BREAKFAST")
+      end
     end
 
     context 'an instance of this class when initialized with a null object' do


### PR DESCRIPTION
`#[]` and `#[]=` will now forward all arguments to the super class if
the provided arguments do not correspond to a property.

Closes #38.
