### PR TITLE
Support for multiple inheritance

### DIFF
--- a/lib/smart_properties.rb
+++ b/lib/smart_properties.rb
@@ -91,6 +91,13 @@ module SmartProperties
     protected :property!
   end
 
+  module ModuleMethods
+    def included(target)
+      super
+      target.include(SmartProperties)
+    end
+  end
+
   class << self
     private
 
@@ -102,6 +109,7 @@ module SmartProperties
     #
     def included(base)
       base.extend(ClassMethods)
+      base.extend(ModuleMethods) if base.is_a?(Module)
     end
   end
 

--- a/lib/smart_properties/property_collection.rb
+++ b/lib/smart_properties/property_collection.rb
@@ -5,18 +5,18 @@ module SmartProperties
     attr_reader :parent
 
     def self.for(scope)
-      parent = scope.ancestors[1..-1].find do |ancestor|
+      parents = scope.ancestors[1..-1].select do |ancestor|
         ancestor.ancestors.include?(SmartProperties) &&
           ancestor != scope &&
           ancestor != SmartProperties
       end
 
-      if parent.nil?
-        new
-      else
-        parent.properties.register(collection = new)
-        collection
+      parents.reduce(collection = new) do |previous, current|
+        current.properties.register(previous)
+        current.properties
       end
+
+      collection
     end
 
     def initialize

--- a/spec/inheritance_spec.rb
+++ b/spec/inheritance_spec.rb
@@ -225,4 +225,34 @@ RSpec.describe SmartProperties, 'intheritance' do
       end
     end
   end
+
+  it "supports multiple inheritance through modules" do
+    m = Module.new do
+      include SmartProperties
+      property :m, default: 1
+    end
+
+    n = Module.new do
+      include SmartProperties
+      property :n, default: 2
+    end
+
+    o = Module.new {}
+
+    klass = Class.new do
+      include m
+      include o
+      include n
+    end
+
+    n.module_eval do
+      property :p, default: 3
+    end
+
+    instance = klass.new
+
+    expect(instance.m).to eq(1)
+    expect(instance.n).to eq(2)
+    expect(instance.p).to eq(3)
+  end
 end


### PR DESCRIPTION
SmartProperties now allows modules to define properties just like classes do and ensures that all properties are eventually included into the target class. Multiple inheritance was previously not supported or required custom `included` hooks.

```ruby
module PII
  include SmartProperties
  property! :name, accepts: String
  property! :email, accepts: String
end

module Job
  property! :title, accepts: String
  property! :company, accepts: String
end

class Person
  include PII
  include Job
end
```
