### PR TITLE
Update rake from Version 12 to Version 13

### DIFF
--- a/smart_properties.gemspec
+++ b/smart_properties.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |gem|
   gem.version       = SmartProperties::VERSION
 
   gem.add_development_dependency "rspec", "~> 3.0"
-  gem.add_development_dependency "rake", "~> 12.0"
+  gem.add_development_dependency "rake", "~> 13.0"
   gem.add_development_dependency "pry"
 end


### PR DESCRIPTION
Updates rake from Version 12 to Version 13. This has no impact on any production code as rake is purely a development dependency.
