### PR TITLE
Child registration

### DIFF
--- a/lib/smart_properties/property_collection.rb
+++ b/lib/smart_properties/property_collection.rb
@@ -75,7 +75,7 @@ module SmartProperties
     end
 
     def refresh(parent_collection)
-      @collection_with_parent_collection = parent_collection.merge(collection)
+      @collection_with_parent_collection.merge!(parent_collection)
       notify_children
       nil
     end

--- a/lib/smart_properties/property_collection.rb
+++ b/lib/smart_properties/property_collection.rb
@@ -11,9 +11,10 @@ module SmartProperties
           ancestor != SmartProperties
       end
 
-      parents.reduce(collection = new) do |previous, current|
-        current.properties.register(previous)
-        current.properties
+      collection = new
+
+      parents.each do |parent|
+        parent.properties.register(collection)
       end
 
       collection

--- a/spec/inheritance_spec.rb
+++ b/spec/inheritance_spec.rb
@@ -254,5 +254,15 @@ RSpec.describe SmartProperties, 'intheritance' do
     expect(instance.m).to eq(1)
     expect(instance.n).to eq(2)
     expect(instance.p).to eq(3)
+
+    expect { klass.new(m: 4, n: 5, p: 6) }.to_not raise_error
+
+    klass2 = Class.new do
+      include n
+      include m
+    end
+
+    expect { klass.new(m: 4, n: 5, p: 6) }.to_not raise_error
+    expect { klass2.new(m: 4, n: 5, p: 6) }.to_not raise_error
   end
 end


### PR DESCRIPTION
Changes the way children register with their parent. The multiple inheritance case was flawed. Ancestors where treated as a linked list when in reality they can be completely independent from one another. Furthermore, the collection with parent collection was recreated on refresh rather than updated.
