### PR TITLE
Reverse order of parent registration

### DIFF
--- a/lib/smart_properties/property_collection.rb
+++ b/lib/smart_properties/property_collection.rb
@@ -13,7 +13,7 @@ module SmartProperties
 
       collection = new
 
-      parents.each do |parent|
+      parents.reverse.each do |parent|
         parent.properties.register(collection)
       end
 


### PR DESCRIPTION
Parents are now registered in reverse order (least significant to most significant). This ensures that a distant ancestor doesn't shadow properties of a closer ancestor.
