### PR TITLE
Fix check for including `ModuleMethods`

### DIFF
--- a/lib/smart_properties.rb
+++ b/lib/smart_properties.rb
@@ -109,7 +109,7 @@ module SmartProperties
     #
     def included(base)
       base.extend(ClassMethods)
-      base.extend(ModuleMethods) if base.is_a?(Module)
+      base.extend(ModuleMethods) unless base.is_a?(Class)
     end
   end
 

--- a/spec/inheritance_spec.rb
+++ b/spec/inheritance_spec.rb
@@ -265,6 +265,24 @@ RSpec.describe SmartProperties, 'intheritance' do
       expect { klass.new(m: 4, n: 5, p: 6) }.to_not raise_error
     end
 
+    it "always extends module with ModuleMethods but never classes" do
+      n = self.n
+
+      klass = Class.new do
+        include n
+      end
+
+      module_singleton_class_ancestors = n.singleton_class.ancestors
+
+      expect(module_singleton_class_ancestors).to include(SmartProperties::ClassMethods)
+      expect(module_singleton_class_ancestors).to include(SmartProperties::ModuleMethods)
+
+      singleton_class_ancestors = klass.singleton_class.ancestors
+
+      expect(singleton_class_ancestors).to include(SmartProperties::ClassMethods)
+      expect(singleton_class_ancestors).not_to include(SmartProperties::ModuleMethods)
+    end
+
     it "yields properly ordered properties – child properties have higher precedence than parent properties" do
       n = self.n
       m = self.m


### PR DESCRIPTION
The parameter passed to `Module.included` is always a `Module` so the check for deciding if the library should inject the `ModuleMethods` was not doing any checks at all.

Since a `Class` is always also a `Module`, the check should check to see if the parameter is not a `Class` instead. This makes sure that `ModuleMethods` is only included into modules and never to classes.

I also added a test to verify these expectations explicitly.