### PR TITLE
chore: add license to gemspec

### DIFF
--- a/smart_properties.gemspec
+++ b/smart_properties.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |gem|
   DESCRIPTION
   gem.summary       = %q{SmartProperties – Ruby accessors on steroids}
   gem.homepage      = ""
+  gem.license       = "MIT"
 
   gem.metadata = {
     "source_code_uri" => "https://github.com/t6d/smart_properties"


### PR DESCRIPTION
Add the SPDX license identifier to the gemspec. See the gemspec [specification](https://guides.rubygems.org/specification-reference/#method-i-license-3D) and the SPDX [MIT entry](https://spdx.org/licenses/MIT.html).